### PR TITLE
Use single quotes to handle repository

### DIFF
--- a/rosco-web/config/packer/aws-chroot.json
+++ b/rosco-web/config/packer/aws-chroot.json
@@ -32,7 +32,7 @@
     "type": "shell",
     "script": "{{user `configDir`}}/install_packages.sh",
     "environment_vars": [
-      "repository={{user `repository`}}",
+      "repository='{{user `repository`}}'",
       "package_type={{user `package_type`}}",
       "packages={{user `packages`}}",
       "upgrade={{user `upgrade`}}",


### PR DESCRIPTION
Repository that contains white spaces (e.g. a deb-s3 style repository such as http://repository trusty main) causes an issue during Packer execution.

This is an example of the error.
amazon-chroot: trusty: 1: trusty: Syntax error: Unterminated quoted string
